### PR TITLE
Support testing all namespaces

### DIFF
--- a/library/src/doo/runner.clj
+++ b/library/src/doo/runner.clj
@@ -2,5 +2,9 @@
   (:require [cljs.test]))
 
 (defmacro doo-tests [& namespaces]
-  `(doo.runner/set-entry-point! 
+  `(doo.runner/set-entry-point!
      (fn [] (cljs.test/run-tests ~@namespaces))))
+
+(defmacro doo-all-tests []
+  `(doo.runner/set-entry-point!
+     (fn [] (cljs.test/run-all-tests))))


### PR DESCRIPTION
It's not that fun to pass all the namespaces through - found an implicit "everything" useful. 

Perhaps cleaner to make this a separate function, but that would require rewording the "didn't import doo" error message :)