### PR TITLE
Node support for relative or absolute paths

### DIFF
--- a/library/resources/runners/node-runner.js
+++ b/library/resources/runners/node-runner.js
@@ -29,7 +29,7 @@ var failIfCljsTestUndefined = function () {
 };
 
 args.forEach(function (arg) {
-    var file = path.join(process.cwd(), arg);
+    var file = path.isAbsolute(arg) ? arg : path.join(process.cwd(), arg);
     global.require = require;
     global.process = process;
     if (fs.existsSync(file)) {


### PR DESCRIPTION
In my use case the output js files live in a Boot fileset - this means that they're temporary files in strange places.