### PR TITLE
Add process.cwd()/node_modules to the module search path in Node runner

### DIFF
--- a/library/resources/runners/node-runner.js
+++ b/library/resources/runners/node-runner.js
@@ -2,6 +2,9 @@ var path = require("path"),
 fs = require("fs"),
 args = process.argv.slice(2);
 
+// Support lein-npm, etc. in the simple case
+module.paths.push(path.join(process.cwd(), 'node_modules'));
+
 var haveCljsTest = function () {
     return (typeof cljs !== "undefined" &&
             typeof cljs.test !== "undefined" &&


### PR DESCRIPTION
This allows projects with Node-specific dependencies to have them be located beneath the project directory.  Without the change, calling `cljs.nodejs/require` won't find a module within project/node_modules, due to the location of the runner script.