### PR TITLE
README: minimum node version required 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ of dated versions.
 
 ### Node
 
+Minimum node version required: `0.12`
+
 `*main-cli-fn*` is not needed (but can be used), since `doo`
 initializes the tests. `:output-dir` is needed whenever you are using `:none`.
 `:hashbang false` and `:target :nodejs` are always needed.


### PR DESCRIPTION
Adds the minimum node version required to the README. Even though there is a line in the [changelog](https://github.com/bensu/doo#changes) about this, I think that's not too visible.

I was tempted to suggest 0.11 as the minimum required version, because I tried with 0.11 and the tests from the example project (and also in a project of mine) run just fine. But perhaps there are other reasons as of why 0.12 is the minimum version per the changelog?
