### PR TITLE
README: Fix cljsbuild example

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ is planned to support `v8`, `jscore`, and others.
 * `build-id` is one of your `cljsbuild` profiles. For example `test` from:
 
 ```clj
-:cljsbuild {:test {:source-paths ["src" "test"]
-    			   :compiler {:output-to "resources/public/js/testable.js"
-                              :main 'your-project.runner
-                              :optimizations :none}}}
+:cljsbuild {
+  :builds {:test {:source-paths ["src" "test"]
+                  :compiler {:output-to "resources/public/js/testable.js"
+                             :main 'your-project.runner
+                             :optimizations :none}}}}
 ```
 
 Notice that `:main` is set to the namespace `your-project.runner`


### PR DESCRIPTION
The previous example had a format that cljsbuild can't understand, so
the test build configuration was not being taken into account by
cljsbuild.

Cljsbuild expects build configurations to be under the `:builds` entry.
It even still supports (but shows a deprecation message) having the
build options right as first level entries in the cljsbuild map, but our
previous version had `:test` as first level and the build options
inside of it.