### PR TITLE
Add regex support to doo-all-tests

### DIFF
--- a/library/src/doo/runner.clj
+++ b/library/src/doo/runner.clj
@@ -8,17 +8,28 @@
            (count (filter (fn [[_ v]] (:test v)) (ana-api/ns-interns ns)))))
     (reduce +)))
 
-(defmacro doo-all-tests []
-  `(doo.runner/set-entry-point!
+(defmacro doo-all-tests
+  "Runs all tests in all namespaces; prints results.
+  Optional argument is a regular expression; only namespaces with
+  names matching the regular expression (with re-matches) will be
+  tested."
+  ([] `(doo-all-tests nil))
+  ([re]
+   `(doo.runner/set-entry-point!
      (if (doo.runner/karma?)
        (fn [tc#]
          (jx.reporter.karma/start tc# ~(count-tests (ana-api/all-ns)))
-         (cljs.test/run-all-tests nil
-           (cljs.test/empty-env :jx.reporter.karma/karma)))
+         (cljs.test/run-all-tests ~re
+                                  (cljs.test/empty-env :jx.reporter.karma/karma)))
        (fn []
-         (cljs.test/run-all-tests)))))
+         (cljs.test/run-all-tests ~re))))))
 
 (defmacro doo-tests [& namespaces]
+  "Runs all tests in the given namespaces; prints results.
+  Defaults to current namespace if none given. Does not return a meaningful
+  value due to the possiblity of asynchronous execution. To detect test
+  completion add a :end-run-tests method case to the cljs.test/report
+  multimethod."
   `(doo.runner/set-entry-point!
      (if (doo.runner/karma?)
        (fn [tc#]


### PR DESCRIPTION
As anticipated, this is the easy change, I have also added the same doc string that you can find in ```cljs.test```. I kept it very simple, forwarding and not checking for now, waiting for new cool ideas that will use strings and not regex.
Let me know if everything is ok.

PS.: testing it in my local rep correctly prunes all unwanted namespaces.