### PR TITLE
Add Circle CI testing for doo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # doo
 
+[![Circle CI](https://circleci.com/gh/bensu/doo.svg?style=svg)](https://circleci.com/gh/bensu/doo)
+
 A library and Leiningen plugin to run `cljs.test` in many JS environments.
 
 >  ...and I would have gotten away with it, too, if it wasn't for you meddling kids.

--- a/README_STABLE.md
+++ b/README_STABLE.md
@@ -1,4 +1,6 @@
-# doo 
+# doo
+
+[![Circle CI](https://circleci.com/gh/bensu/doo.svg?style=svg)](https://circleci.com/gh/bensu/doo)
 
 A library and Leiningen plugin to run `cljs.test` in many JS environments.
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,53 @@
+dependencies:
+  pre:
+    - cd example && npm install
+    - cd example && npm install karma-cli -g
+    - cd example && lein deps
+    - cd library && lein deps
+  cache_directories:
+    - example/node_modules
+    - ~/.m2
+test:
+  override:
+    # Passing tests
+    # Karma
+    - cd example && lein doo browsers test once
+    - cd example && lein doo browsers advanced once
+    - cd example && lein doo browsers none-test once
+    # Phantom
+    - cd example && lein doo phantom test once
+    - cd example && lein doo phantom advanced once
+    - cd example && lein doo phantom none-test once
+    # Slimer
+    - cd example && lein doo slimer test once
+    - cd example && lein doo slimer advanced once
+    - cd example && lein doo slimer none-test once
+    # Rhino
+    - cd example && lein doo rhino test once
+    - cd example && lein doo rhino advanced once
+    # rhino doesn't support :none optimisations
+    # Node
+    - cd example && lein doo node node-none once
+    - cd example && lein doo node node-advanced once
+    # These ones should fail
+    # Karma
+    - cd example && lein doo browsers test-fail once && exit 1 || exit 0
+    - cd example && lein doo browsers advanced-fail once && exit 1 || exit 0
+    - cd example && lein doo browsers none-test-fail once && exit 1 || exit 0
+    # Phantom
+    - cd example && lein doo phantom test-fail once && exit 1 || exit 0
+    - cd example && lein doo phantom advanced-fail once && exit 1 || exit 0
+    - cd example && lein doo phantom none-test-fail once && exit 1 || exit 0
+    # Slimer
+    - cd example && lein doo slimer test-fail once && exit 1 || exit 0
+    - cd example && lein doo slimer advanced-fail once && exit 1 || exit 0
+    - cd example && lein doo slimer none-test-fail once && exit 1 || exit 0
+    # Rhino
+    - cd example && lein doo rhino test-fail once && exit 1 || exit 0
+    - cd example && lein doo rhino advanced-fail once && exit 1 || exit 0
+    - cd example && lein doo rhino none-test-fail once && exit 1 || exit 0
+    # Node
+    - cd example && lein doo node node-none-fail once && exit 1 || exit 0
+    - cd example && lein doo node node-advanced-fail once && exit 1 || exit 0
+    # Test the actual library itself
+    - cd library && lein test

--- a/example/failing-tests/example/failing_runner.cljs
+++ b/example/failing-tests/example/failing_runner.cljs
@@ -1,0 +1,6 @@
+(ns example.failing-runner
+  (:require [cljs.test :as test]
+            [doo.runner :refer-macros [doo-all-tests doo-tests]]
+            [example.failing-test]))
+
+(doo-tests 'example.failing-test)

--- a/example/failing-tests/example/failing_test.cljs
+++ b/example/failing-tests/example/failing_test.cljs
@@ -1,0 +1,26 @@
+(ns example.failing-test
+  (:require-macros [cljs.core.async.macros :refer [go]])
+  (:require [cljs.test :refer-macros [async deftest is testing]]
+            [cljs.core.async :as async :refer [chan put! <!]]
+            [example.core :as core]))
+
+(deftest adding
+         (is (= 3 (core/adder 1 1))))
+
+(deftest async-test
+         (async done
+                (let [a 1]
+                  (js/setTimeout (fn []
+                                   (is (= 1 a))
+                                   (done))
+                                 100)
+                  (is (= 2 a)))))
+
+(deftest csp-test
+         (async done
+                (let [val 1
+                      ch (chan)]
+                  (go (let [a (<! ch)]
+                        (is (= a :not-a))
+                        (done)))
+                  (put! ch val))))

--- a/example/package.json
+++ b/example/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {},
+  "devDependencies": {
+    "karma": "^0.13.14",
+    "karma-chrome-launcher": "^0.2.1",
+    "karma-cljs-test": "^0.1.0",
+    "karma-firefox-launcher": "^0.1.6",
+    "slimerjs": "^0.9.6"
+  }
+}

--- a/example/project.clj
+++ b/example/project.clj
@@ -11,40 +11,76 @@
   :plugins [[lein-cljsbuild "1.0.5"]
             [lein-doo "0.1.6-SNAPSHOT"]]
 
-  :source-paths ["src" "test"]
+  :source-paths ["src" "test" "failing-tests"]
 
   :clean-targets ^{:protect false} [:target-path "resources/public/js/" "out"]
-  
+
   :doo {:build "test"
-        :paths {:karma "karma"}
+        :paths {:karma "karma"
+                :slimer "./node_modules/.bin/slimerjs"}
         :alias {:browsers [:chrome :firefox]
                 :all [:browsers :headless]}}
 
+  :jvm-opts ["-Xmx1g"]
+
   :cljsbuild
-  {:builds {:dev {:source-paths ["src"]
-                  :compiler {:output-to "resources/public/js/dev.js"
-                             :main example.core
-                             :optimizations :none}}
-            :test {:source-paths ["src" "test"]
-                   :compiler {:output-to "out/testable.js"
-                              :main 'example.runner
-                              :optimizations :simple}}
-            :advanced {:source-paths ["src" "test"]
-                       :compiler {:output-to "out/testable.js"
-                                  :main "example.runner"
-                                  :optimizations :advanced}}
-            :none-test {:source-paths ["src" "test"]
-                        :compiler {:output-to "out/testable.js"
-                                   :main example.runner
-                                   :source-map true
-                                   :optimizations :none}}
-            :node-none {:source-paths ["src" "test"]
-                        :compiler {:output-to "out/testable.js"
-                                   :main example.runner
-                                   :optimizations :none
-                                   :target :nodejs}}
-            :node-advanced {:source-paths ["src" "test"]
-                            :compiler {:output-to "out/testable.js"
-                                       :main example.runner
-                                       :optimizations :advanced
-                                       :target :nodejs}}}})
+  {:builds {:dev                {:source-paths ["src"]
+                                 :compiler     {:output-to     "resources/public/js/dev.js"
+                                                :main          example.core
+                                                :optimizations :none}}
+            :test               {:source-paths ["src" "test"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          'example.runner
+                                                :optimizations :simple}}
+            :advanced           {:source-paths ["src" "test"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          "example.runner"
+                                                :optimizations :advanced}}
+            :none-test          {:source-paths ["src" "test"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          example.runner
+                                                :source-map    true
+                                                :optimizations :none}}
+            :node-none          {:source-paths ["src" "test"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          example.runner
+                                                :optimizations :none
+                                                :target        :nodejs}}
+            :node-advanced      {:source-paths ["src" "test"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          example.runner
+                                                :optimizations :advanced
+                                                :target        :nodejs}}
+
+            ;; These cljsbuild configs are for CI testing only.
+            :dev-fail           {:source-paths ["src"]
+                                 :compiler     {:output-to     "resources/public/js/dev.js"
+                                                :main          example.core
+                                                :optimizations :none}}
+            :test-fail          {:source-paths ["src" "failing-tests"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          'example.failing-runner
+                                                :optimizations :simple}}
+            :advanced-fail      {:source-paths ["src" "failing-tests"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          "example.failing-runner"
+                                                :optimizations :advanced}}
+            :none-test-fail     {:source-paths ["src" "failing-tests"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          example.failing-runner
+                                                :source-map    true
+                                                :optimizations :none}}
+            :node-none-fail     {:source-paths ["src" "failing-tests"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          example.failing-runner
+                                                :optimizations :none
+                                                :target        :nodejs}}
+            :node-advanced-fail {:source-paths ["src" "failing-tests"]
+                                 :compiler     {:output-to     "out/testable.js"
+                                                :main          example.failing-runner
+                                                :optimizations :advanced
+                                                :target        :nodejs}}
+
+            }
+
+   })

--- a/library/project.clj
+++ b/library/project.clj
@@ -8,17 +8,19 @@
         :url "https://github.com/bensu/doo"}
 
   :deploy-repositories [["clojars" {:creds :gpg}]]
-  
+
   :test-paths ["test/clj"]
 
   :resource-paths ["resources"]
-  
+
   :clean-targets ^{:protect false} [:target-path "out"]
 
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/data.json "0.2.6"]
                  [karma-reporter "0.1.0"]]
-  
+
+  :jvm-opts ["-Xmx1g"]
+
   :profiles
   {:dev {:source-paths ["src/clj" "test/clj" "../example/src" "../example/test"]
          :dependencies [[org.clojure/core.async "0.1.346.0-17112a-alpha"]]}})


### PR DESCRIPTION
Circle CI is the easiest CI tool for running browser based tests. They already have Chrome installed and you don't need to mess around with `xvfb` to get it running.

This commit adds a few things:
- JVM opts for the project.clj - You need to provide this for Circle
  because they run it on boxes with oodles of RAM, but you're only able
  to access 4GB of it. If you don't specify xmx yourself, then the OS
  will try to use more than 4GB.
- CI badge - fairly self explanatory.
- Add NPM package.json for installing node dependencies to example
  project.
- Add failing cljsbuild configs to the example project to be used for
  testing.
- Adds a Circle testing script to run the tests and check the output.

You'll need to signup for Circle to be able to run this. They have a free tier. You can see the results of my tests at https://circleci.com/gh/danielcompton/doo/10#commits. Of note, the tests for library are failing at the moment.

I put all of the stuff related to tests failing in the example project to keep it in one place, but I understand it makes things a little messier.

Fixes #54.