### PR TITLE
Add Windows support to doo

### DIFF
--- a/library/src/doo/shell.clj
+++ b/library/src/doo/shell.clj
@@ -1,6 +1,7 @@
 (ns doo.shell
   "Rewrite of clojure.java.shell to have access to the output stream."
-  (:require [clojure.java.io :as io])
+  (:require [clojure.java.io :as io]
+            [doo.utils :as utils])
   (:import (java.io StringWriter BufferedReader InputStreamReader)
            (java.nio.charset Charset)))
 
@@ -37,7 +38,12 @@
       (.toString out))))
 
 (defn exec! [cmd]
-  (.exec (Runtime/getRuntime) ^"[Ljava.lang.String;" (into-array cmd)))
+  (let [windows? (= :windows (utils/get-os))
+        windows-cmd (when windows? ["cmd" "/c"])]
+    (->> cmd
+         (concat windows-cmd)
+         ^"[Ljava.lang.String;" (into-array String)
+         (.exec (Runtime/getRuntime)))))
 
 (defn capture-process! [process opts]
   (letfn [(capture! [stream]

--- a/library/src/doo/utils.clj
+++ b/library/src/doo/utils.clj
@@ -1,0 +1,30 @@
+(ns doo.utils
+  "Taken from leiningen.core.utils"
+  (:require [clojure.java.io :as io]))
+
+(defn- get-by-pattern
+  "Gets a value from map m, but uses the keys as regex patterns, trying
+  to match against k instead of doing an exact match."
+  [m k]
+  (m (first (drop-while #(nil? (re-find (re-pattern %) k))
+                        (keys m)))))
+
+(defn- get-with-pattern-fallback
+  "Gets a value from map m, but if it doesn't exist, fallback
+   to use get-by-pattern."
+  [m k]
+  (let [exact-match (m k)]
+    (if (nil? exact-match)
+      (get-by-pattern m k)
+      exact-match)))
+
+(def ^:private native-names
+  {"Mac OS X" :macosx "Windows" :windows "Linux" :linux
+   "FreeBSD"  :freebsd "OpenBSD" :openbsd
+   "amd64"    :x86_64 "x86_64" :x86_64 "x86" :x86 "i386" :x86
+   "arm"      :arm "SunOS" :solaris "sparc" :sparc "Darwin" :macosx})
+
+(defn get-os
+  "Returns a keyword naming the host OS."
+  []
+  (get-with-pattern-fallback native-names (System/getProperty "os.name")))


### PR DESCRIPTION
Shell commands on windows needs to be run by `cmd`. This commit checks if doo is running on Windows, and if so adds the appropriate incantations.

Unfortunately it doesn't seem like Travis or Circle support Windows. I've tested it on our Windows projects and the example project (Karma only, as installing all of the other tools is a real pain).