### PR TITLE
Install Rhino and Karma for library tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,10 @@ To run on [travis](https://travis-ci.org/) there is a sample `.travis.yml` file 
 code reflecting if the tests failed, to be used in CI builds. It also
 **requires [org.clojure/clojurescript "0.0-3308"]** or newer.
 
+## Developing
+
+To run the tests for doo, you need to have installed rhino, phantomjs, slimer, chrome, node, and firefox. You will also need to run `npm install` in the `library` directory.
+
 ## License
 
 Most code in this project is a repackaging of

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,8 @@ dependencies:
     - cd example && npm install karma-cli -g
     - cd example && lein deps
     - cd library && lein deps
+    - cd library && npm install
+    - sudo apt-get update; sudo apt-get install rhino
   cache_directories:
     - example/node_modules
     - ~/.m2

--- a/library/.gitignore
+++ b/library/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+node_modules/

--- a/library/package.json
+++ b/library/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "library",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {},
+  "devDependencies": {
+    "karma": "^0.13.15",
+    "karma-chrome-launcher": "^0.2.1",
+    "karma-cljs-test": "^0.1.0",
+    "karma-firefox-launcher": "^0.1.7"
+  }
+}


### PR DESCRIPTION
Circle CI doesn't have Rhino installed by default, and the library needs a local Karma install. Add instructions for local developers.

Fixes #61.