### PR TITLE
Execute command from :output-to directory

### DIFF
--- a/library/src/doo/core.clj
+++ b/library/src/doo/core.clj
@@ -238,7 +238,7 @@ where:
    (run-script js-env compiler-opts {}))
   ([js-env compiler-opts opts]
    {:pre [(valid-js-env? js-env)]}
-   (let [doo-opts (merge default-opts opts)
+   (let [doo-opts (merge default-opts {:base-dir (:output-to compiler-opts)} opts)
          cmd (conj (js->command js-env compiler-opts doo-opts)
                    (:output-to compiler-opts))]
      (try

--- a/library/src/doo/core.clj
+++ b/library/src/doo/core.clj
@@ -216,6 +216,9 @@ If it does work, file an issue and we'll sort it together!")
 (def default-opts {:verbose true
                    :karma {:install? false}})
 
+(defn- abs-path [path]
+  (.getAbsolutePath (File. path)))
+
 (defn run-script
   "Runs the script defined in :output-to of compiler-opts
    in the selected js-env.
@@ -240,7 +243,7 @@ where:
    {:pre [(valid-js-env? js-env)]}
    (let [doo-opts (merge default-opts {:base-dir (:output-to compiler-opts)} opts)
          cmd (conj (js->command js-env compiler-opts doo-opts)
-                   (:output-to compiler-opts))]
+                   (abs-path (:output-to compiler-opts)))]
      (try
        (let [r (shell/sh cmd doo-opts)]
          ;; Phantom/Slimer don't return correct exit code when


### PR DESCRIPTION
A bit rough, but served for me to test that this would fix `:none` builds via the Boot tooling.

Perhaps taking`doo-opts` for this directly would be more appropriate? This would support more exotic paths (eg. dev build of Nashorn)

Also perhaps this behaviour of automatically using the compile directory could be an option.

Refs #68 