### PR TITLE
Add support for Chrome Canary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `:debug` option to `doo.core/run-script`.
+- Support for running Chrome Canary. Call it from the command line as `lein doo chrome-canary test once` or add it to `:browsers` as `:chrome-canary`. [#73](https://github.com/bensu/doo/pull/73)
 
 ## [0.1.6-rc.1] - 2015-11-23
 

--- a/library/src/doo/karma.clj
+++ b/library/src/doo/karma.clj
@@ -9,10 +9,27 @@
 ;; ======================================================================
 ;; Karma Clients
 
-(def envs #{:chrome :firefox :safari :opera :ie})
+(defn- karma-plugin-name [name]
+  (str "karma-" name "-launcher"))
+
+(def browser-envs
+  {:chrome        {:plugin (karma-plugin-name "chrome")
+                   :name   "Chrome"}
+   :chrome-canary {:plugin (karma-plugin-name "chrome")
+                   :name   "ChromeCanary"}
+   :firefox       {:plugin (karma-plugin-name "firefox")
+                   :name   "Firefox"}
+   :safari        {:plugin (karma-plugin-name "safari")
+                   :name   "Safari"}
+   :opera         {:plugin (karma-plugin-name "opera")
+                   :name   "Opera"}
+   :ie            {:plugin (karma-plugin-name "ie")
+                   :name   "IE"}})
+
+(def envs (set (keys browser-envs)))
 
 (defn env? [js]
-  (contains? envs js))
+  (contains? browser-envs js))
 
 ;; In Karma all paths (including config.files) are normalized to
 ;; absolute paths using the basePath.
@@ -30,12 +47,10 @@
 ;; https://github.com/clojure/clojurescript/blob/master/src/main/clojure/cljs/closure.clj#L1152
 
 (defn js-env->plugin [js-env]
-  (str "karma-" (name js-env) "-launcher"))
+  (get-in browser-envs [js-env :plugin]))
 
 (defn js-env->browser [js-env]
-  (if (= :ie js-env)
-    "IE"
-    (str/capitalize (name js-env))))
+  (get-in browser-envs [js-env :name]))
 
 (defn ->karma-opts [js-envs compiler-opts]
   (letfn [(->out-dir [p]


### PR DESCRIPTION
Chrome Canary is launched via the karma-chrome-launcher. To support launching two different browsers via one plugin, I could either add a further special case to js-env->plugin and js-env->browser, or refactor the karma code in light of this new use case. I chose the latter as I think it should be more maintainable and less error prone in the long run.

I could be persuaded the other way to add special cases for Chrome Canary if you preferred that more.