### PR TITLE
Add appveyor config for Windows testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # doo
 
 [![Circle CI](https://circleci.com/gh/bensu/doo.svg?style=svg)](https://circleci.com/gh/bensu/doo)
+[![Build status](https://ci.appveyor.com/api/projects/status/ne9jl0hixjkbpwgk/branch/master?svg=true)](https://ci.appveyor.com/project/danielcompton/doo/branch/master)
 
 A library and Leiningen plugin to run `cljs.test` in many JS environments.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: 1.0.{build}
+install:
+- ps: >-
+    New-Item c:\scripts -type directory
+
+    $env:Path += ";C:\scripts"
+
+    Invoke-WebRequest -Uri https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein.bat -OutFile "C:\scripts\lein.bat"
+
+    lein self-install
+
+    lein version
+build_script:
+- cmd: >-
+    cd example
+
+    npm install
+
+    npm install karma-cli -g
+
+    lein deps
+
+    karma --version
+
+    cd ..
+test_script:
+- cmd: "cd example \nlein doo browsers test once\nlein doo browsers advanced once\nlein doo browsers none-test once"


### PR DESCRIPTION
You can set this up on your GitHub account at https://github.com/integrations/appveyor. You'll also need to update the README icon. This only runs a small portion of the tests that run in CircleCI, but it should serve at least as a smoke test. I'm not a masochist, but perhaps @conan might want to try installing Phantom in Appveyor so we can test the Phantom runner too, once #60 is resolved.