### PR TITLE
Simply code around `exec!`

### DIFF
--- a/library/src/doo/core.clj
+++ b/library/src/doo/core.clj
@@ -243,7 +243,7 @@ where:
     :debug - bool (default false) to log to standard-out internal events
              to aid debugging
     :paths - a map from runners (keywords) to string commands for bash.
-    :exec-dir - a directory path (string) from where runner should be
+    :exec-dir - a directory path (file) from where runner should be
                 exectuted. Defaults to nil which resolves to the current dir"
   ([js-env compiler-opts]
    (run-script js-env compiler-opts {}))

--- a/library/src/doo/shell.clj
+++ b/library/src/doo/shell.clj
@@ -62,7 +62,8 @@
    (set-cleanup! process opts "Shutdown Process"))
   ([process opts msg]
    (.addShutdownHook (Runtime/getRuntime)
-     (Thread. (fn []
+     (Thread. ^Runnable
+              (fn []
                 (println msg)
                 (.destroy process))))))
 

--- a/library/src/doo/shell.clj
+++ b/library/src/doo/shell.clj
@@ -37,20 +37,16 @@
       (.close r)
       (.toString out))))
 
-(defn -exec
-  ([command-arr]
-    (.exec (Runtime/getRuntime) command-arr))
-  ([command-arr working-dir]
-   (.exec (Runtime/getRuntime) command-arr nil working-dir)))
+(defn- ^"[Ljava.lang.String;" str-array [xs]
+  (into-array String xs))
 
-(defn exec! [cmd exec-dir]
+(defn exec! [cmd ^File exec-dir]
   (let [windows? (= :windows (utils/get-os))
         windows-cmd (when windows? ["cmd" "/c"])
-        exec* (if exec-dir #(-exec % exec-dir) -exec)]
-    (->> cmd
-         (concat windows-cmd)
-         ^"[Ljava.lang.String;" (into-array String)
-         exec*)))
+        command-arr (str-array (concat windows-cmd cmd))]
+    (if exec-dir
+      (.exec (Runtime/getRuntime) command-arr nil exec-dir)
+      (.exec (Runtime/getRuntime) command-arr))))
 
 (defn capture-process! [process opts]
   (letfn [(capture! [stream]


### PR DESCRIPTION
Given @danielcompton's feedback, here's a version more to my own taste. Pushing for multi-arity just made things awkward in my opinion!

You may notice that the cleanup surfaced something embarrassing - the `exec-dir` parameter needs to be a `File`, not a string as I documented..

As for the other feedback (documentation and tests), would appreciate guidance:

1. Where besides docstring to document options - a new section in the README? Wiki?
2. Suggestion to test option with boot - would this mean depending on or including `boot-cljs-test`?

Doo is welcome to absorb `boot-cljs-test`, it's really just another "plugin". Created a separate project simply for discoverability - "where is `boot-test` for CLJS?"

Otherwise maybe a non-boot test case would be better.
