### PR TITLE
Remove exit(1) in onError for headless runner

### DIFF
--- a/library/resources/runners/headless.js
+++ b/library/resources/runners/headless.js
@@ -40,7 +40,6 @@ p.onConsoleMessage = function(msg) {
 
 p.onError = function(msg) {
     console.error(msg);
-    exit(1);
 };
 
 p.open("file://" + pagePath, function (status) {


### PR DESCRIPTION
This removes the `exit` in `headless.js` -> `onError`.

I met another weird case were [this warning](https://travis-ci.org/ScalaConsultants/replumb/builds/96880828#L392) is actually printed by `Clojurescript` core on the error output and the tests were failing.

Even if it is an error message, IMHO it should not probably cause the entire process to exit,that's the reason of this patch. A future option for doo could be to have a flag that specifies whether to exit on error messages...or fail on error messages.

In my case I don't need either, but just go ahead and complete the tests (I can't merge [this](https://github.com/ScalaConsultants/replumb/pull/84) otherwise).

I am also open to workarounds in case you don't like it or things break.