### PR TITLE
Add a dummy definition for `document` to the Nashorn runner.

### DIFF
--- a/library/resources/runners/nashorn.js
+++ b/library/resources/runners/nashorn.js
@@ -7,6 +7,11 @@ console.debug = print;
 console.warn = print;
 console.log = print;
 
+// This enables some applications that would otherwise not work
+// and gives better error messages than others.
+
+var document = {};
+
 var setTimeout, clearTimeout, setInterval, clearInterval;
 
 (function () {


### PR DESCRIPTION
This enables a few programs (for example, headless React tests),
and outputs better error messages for others.