### PR TITLE
Permit (:builds (:cljsbuild project)) to be a list.

### DIFF
--- a/plugin/src/leiningen/doo.clj
+++ b/plugin/src/leiningen/doo.clj
@@ -77,7 +77,8 @@
                   (update-in [:compiler] correct-main)))
           builds)
 
-        (vector? builds) (mapv #(update-in % [:compiler] correct-main) builds)
+        (or (vector? builds) (seq? builds))
+        (mapv #(update-in % [:compiler] correct-main) builds)
 
         :else (throw (Exception. ":cljsbuild :builds needs to be either a vector or a map"))))))
 


### PR DESCRIPTION
When the builds collection is part of a [composite profile](https://github.com/technomancy/leiningen/blob/master/doc/PROFILES.md#composite-profiles), it may be a list instead of a vector. This is probably a bug in Leiningen, and I have [reported](https://github.com/technomancy/leiningen/issues/2119) it, but this commit provides a trivial workaround: apply `mapv` to the builds collection whether it is a vector or a seq. The result becomes a vector.

I know not all maintainers welcome pull requests without previous discussion. Just let me know what you'd prefer.