### PR TITLE
Support for custom Karma launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,23 @@ default build in your `project.clj`:
                         :main example.runner}}]}
 ```
 
+## Custom Karma Launchers
+
+To add custom Karma launchers  (eg. as described in the [Chrome Karma Plugin](https://github.com/karma-runner/karma-chrome-launcher) you can add the following config entries to your `project.clj` as shown in the example below:
+
+The plugin in the :launchers map should match an installed karma plugin and the name should match a Karma launcher (possibly a custom one as shown in the following example)
+
+Any values in the :config key will be converted to json and merged with the karma.conf.js configuration used to launch Karma.
+
+You will then be able to run `lein doo chrome-no-security` from the comand line.
+
+```clj
+:doo {:karma {:launchers {:chrome-no-security {:plugin "karma-chrome-launcher" :name "Chrome_no_security"}}
+              :config {"customLaunchers"
+                         {"Chrome_no_security" {"base" "Chrome"
+                                                "flags" ["--disable-web-security"]}}}}
+```
+
 ## Travis CI
 
 To run on [travis](https://travis-ci.org/) there is a sample `.travis.yml` file in the example project: [example/.travis.yml](example/.travis.yml)

--- a/example/project.clj
+++ b/example/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-doo-example "0.1.7-SNAPSHOT"
+(defproject lein-doo-example "0.1.8-SNAPSHOT"
   :description "Project to test lein-doo. Do not take it as an example"
   :url "https://github.com/bensu/doo"
   :license {:name "Eclipse Public License"
@@ -9,7 +9,7 @@
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]]
 
   :plugins [[lein-cljsbuild "1.0.5"]
-            [lein-doo "0.1.7-SNAPSHOT"]]
+            [lein-doo "0.1.8-SNAPSHOT"]]
 
   :source-paths ["src" "test" "failing-tests"]
 
@@ -19,7 +19,11 @@
         :paths {:slimer "./node_modules/.bin/slimerjs"}
         :alias {:default [:slimer]
                 :browsers [:chrome :firefox]
-                :all [:browsers :headless]}}
+                :all [:browsers :headless]}
+        :karma {:launchers {:chrome-no-security {:plugin "karma-chrome-launcher" :name "Chrome_no_security"}}
+                :config {"customLaunchers"
+                         {"Chrome_no_security" {"base" "Chrome"
+                                                "flags" ["--disable-web-security"]}}}}}
 
   :jvm-opts ["-Xmx1g"]
 

--- a/library/package.json
+++ b/library/package.json
@@ -5,11 +5,11 @@
   "dependencies": {},
   "devDependencies": {
     "electron-prebuilt": "^1.2.1",
-    "karma": "^0.13.15",
-    "karma-chrome-launcher": "^0.2.1",
+    "karma": "^0.13.22",
+    "karma-chrome-launcher": "^1.0.1",
     "karma-cljs-test": "^0.1.0",
     "karma-electron-launcher": "^0.1.0",
-    "karma-firefox-launcher": "^0.1.7",
+    "karma-firefox-launcher": "^1.0.0",
     "karma-phantomjs-launcher": "^1.0.0",
     "karma-slimerjs-launcher": "^1.0.0",
     "phantomjs-prebuilt": "^2.1.7"

--- a/library/project.clj
+++ b/library/project.clj
@@ -1,4 +1,4 @@
-(defproject doo "0.1.7-SNAPSHOT"
+(defproject doo "0.1.8-SNAPSHOT"
   :description "doo is a library to run clj.test on different js environments."
   :url "https://github.com/bensu/doo"
   :license {:name "Eclipse Public License"

--- a/library/src/doo/karma.clj
+++ b/library/src/doo/karma.clj
@@ -75,7 +75,6 @@
       ;; basePath should be the path from where the compiler thinks the
       ;; resources will be served: :asset-path or :output-dir
       "basePath" (System/getProperty "user.dir")
-      "plugins" (into ["karma-cljs-test"] (mapv #(js-env->plugin % (custom-launchers opts)) js-envs))
       "browsers" (mapv #(js-env->browser % (custom-launchers opts)) js-envs)
       ;; All this assumes that the output-dir is relative to the user.dir
       ;; base path
@@ -90,7 +89,10 @@
       "autoWatch" false
       "client" {"args" ["doo.runner.run_BANG_"]}
       "singleRun" true}     
-     (get-in opts [:karma :config]))))
+     (get-in opts [:karma :config])
+     {"plugins" (into ["karma-cljs-test"]
+                      (concat (mapv #(js-env->plugin % (custom-launchers opts)) js-envs)
+                              (get-in opts [:karma :config "plugins"])))})))
 
 (defn write-var [writer var-name var-value]
   (.write writer (str "var " var-name " = "))

--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-doo "0.1.7-SNAPSHOT"
+(defproject lein-doo "0.1.8-SNAPSHOT"
   :description "lein-doo is a plugin to run clj.test on different js environments."
   :url "https://github.com/bensu/doo"
   :license {:name "Eclipse Public License"
@@ -12,7 +12,7 @@
   :eval-in-leiningen true
 
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [doo "0.1.7-SNAPSHOT"]]
+                 [doo "0.1.8-SNAPSHOT"]]
 
   :test-paths ["test/clj" "test/cljs"]
 


### PR DESCRIPTION
I'm using lein-doo  to test a clojurescript chrome plugin and I needed to be able to launch chrome with the "--load-extension=target/chrome" command line argument. 

This pull request allows you to add new karma launch configurations in the project.clj and run them from lein doo. There's an example in readme.md and the sample project
