### PR TITLE
Add support for Chrome headless

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ in `project.clj`:
 * `js-env` can be any `chrome`, `firefox`, `ie`, `safari`, `opera`,
 `slimer`, `phantom`, `node`, `rhino`, or `nashorn`. In the future it
 is planned to support `v8`, `jscore`, and others.
+  * Note that `chrome-headless` requires `karma-chrome-launcher` >= 2.0.0 and Chrome >= 59
 * `watch-mode` (optional): either `auto` (default) or `once` which
   exits with 0 if the tests were successful and 1 if they failed.
 * `build-id` is one of your `cljsbuild` profiles. For example `test` from:

--- a/library/src/doo/karma.clj
+++ b/library/src/doo/karma.clj
@@ -14,24 +14,26 @@
   (str "karma-" name "-launcher"))
 
 (def karma-envs
-  {:chrome        {:plugin (karma-plugin-name "chrome")
-                   :name   "Chrome"}
-   :chrome-canary {:plugin (karma-plugin-name "chrome")
-                   :name   "ChromeCanary"}
-   :firefox       {:plugin (karma-plugin-name "firefox")
-                   :name   "Firefox"}
-   :safari        {:plugin (karma-plugin-name "safari")
-                   :name   "Safari"}
-   :opera         {:plugin (karma-plugin-name "opera")
-                   :name   "Opera"}
-   :ie            {:plugin (karma-plugin-name "ie")
-                   :name   "IE"}
-   :karma-phantom {:plugin (karma-plugin-name "phantomjs")
-                   :name   "PhantomJS"}
-   :karma-slimer  {:plugin (karma-plugin-name "slimerjs")
-                   :name   "SlimerJS"}
-   :electron      {:plugin (karma-plugin-name "electron")
-                   :name   "Electron"}})
+  {:chrome          {:plugin (karma-plugin-name "chrome")
+                     :name   "Chrome"}
+   :chrome-canary   {:plugin (karma-plugin-name "chrome")
+                     :name   "ChromeCanary"}
+   :chrome-headless {:plugin (karma-plugin-name "chrome")
+                     :name   "ChromeHeadless"}
+   :firefox         {:plugin (karma-plugin-name "firefox")
+                     :name   "Firefox"}
+   :safari          {:plugin (karma-plugin-name "safari")
+                     :name   "Safari"}
+   :opera           {:plugin (karma-plugin-name "opera")
+                     :name   "Opera"}
+   :ie              {:plugin (karma-plugin-name "ie")
+                     :name   "IE"}
+   :karma-phantom   {:plugin (karma-plugin-name "phantomjs")
+                     :name   "PhantomJS"}
+   :karma-slimer    {:plugin (karma-plugin-name "slimerjs")
+                     :name   "SlimerJS"}
+   :electron        {:plugin (karma-plugin-name "electron")
+                     :name   "Electron"}})
 
 (def envs (set (keys karma-envs)))
 

--- a/library/test/clj/test/doo/core.clj
+++ b/library/test/clj/test/doo/core.clj
@@ -48,7 +48,7 @@
     (are [js-env] (doo/valid-js-env? js-env)
       :rhino :nashorn :slimer :phantom :node
       :chrome :safari :firefox :opera :ie :electron
-      :karma-phantom :karma-slimer))
+      :karma-phantom :karma-slimer :chrome-headless))
   (testing "We can resolve aliases"
     (are [alias js-envs] (= (doo/resolve-alias alias {}) js-envs)
          :phantom [:phantom]


### PR DESCRIPTION
https://github.com/karma-runner/karma-chrome-launcher now has support for headless chrome.

This adds the option to run `lein doo` with karma in headless chrome by passing `chrome-headless` as a `js-env` (i.e. `lein doo chrome-headless`).

To test this, make sure you have:
- `karma-chrome-launcher >= 2.0.0`
- Chrome >= 59