### PR TITLE
Support managed dependencies in projects

### DIFF
--- a/plugin/src/leiningen/doo.clj
+++ b/plugin/src/leiningen/doo.clj
@@ -28,7 +28,8 @@
                     :repositories
                     :resource-paths
                     :source-paths
-                    :dependencies])
+                    :dependencies
+                    :managed-dependencies])
       (assoc :local-repo-classpath true)
       (with-meta (meta project))))
 

--- a/plugin/test/clj/test/lein_doo/config.clj
+++ b/plugin/test/clj/test/lein_doo/config.clj
@@ -83,3 +83,17 @@
            []
            ["chrome"]
            ["chrome" "once"]))))
+
+(deftest run-local-project
+  (testing "Project with managed dependencies can be evaluated"
+    (let [project {:source-paths ["src" "src/main/clj"]
+                   :test-paths ["test" "src/test/clj"]
+                   :managed-dependencies [['org.clojure/clojure "1.8.0"]]
+                   :dependencies [['org.clojure/clojure]]
+                   :cljsbuild {:builds [{:id "test"
+                                         :source-paths ["src" "test"]
+                                         :compiler {:optimizations :simple
+                                                    :output-to "out/testable.js"}}]}}
+          result (try (doo/run-local-project project '() '(+ 1 1)) (catch IllegalArgumentException e e))]
+      (is (nil? result) "Expected that running the local project with managed-dependencies evaluates successfully"))))
+

--- a/plugin/test/clj/test/lein_doo/config.clj
+++ b/plugin/test/clj/test/lein_doo/config.clj
@@ -88,7 +88,7 @@
   (testing "Project with managed dependencies can be evaluated"
     (let [project {:source-paths ["src" "src/main/clj"]
                    :test-paths ["test" "src/test/clj"]
-                   :managed-dependencies [['org.clojure/clojure "1.8.0"]]
+                   :managed-dependencies [['org.clojure/clojure "1.7.0"]]
                    :dependencies [['org.clojure/clojure]]
                    :cljsbuild {:builds [{:id "test"
                                          :source-paths ["src" "test"]


### PR DESCRIPTION
Using doo in a project that makes use of managed-dependencies (introduced in leiningen ~2.7) results in a failure when running any doo command:

```
Provided artifact is missing a version: [org.clojure/clojure nil]
```

Sample project:
```
(defproject doo-fail-sample "1.0.0-SNAPSHOT"
 :managed-dependencies [[org.clojure/clojure "1.8.0]
                 [org.clojure/clojurescript "1.9.854"]]
  :dependencies [[org.clojure/clojure]
                 [org.clojure/clojurescript]]

  :profiles {:dev {:plugins [[lein-cljsbuild "1.1.7"]
                             [lein-doo "0.1.7"]]

                   :doo {:build "test"}

                   :cljsbuild {:builds {:test {:source-paths ["src" "test"]
                                               :compiler     {:main          my.doo-runner
                                                              :asset-path    "/js/out"
                                                              :output-to     "target/test.js"
                                                              :output-dir    "target/cljstest/public/js/out"
                                                              :optimizations :whitespace
                                                              :pretty-print  true}}}}}})
```

Running (for example):
```
lein doo phantom
```

Easiest way to replicate is to remove the fix in `plugin/src/leiningen/doo.clj` and run the provided test.
