### PR TITLE
Support Lein 2.7.0 :managed-dependencies

### DIFF
--- a/plugin/src/leiningen/doo.clj
+++ b/plugin/src/leiningen/doo.clj
@@ -28,7 +28,8 @@
                     :repositories
                     :resource-paths
                     :source-paths
-                    :dependencies])
+                    :dependencies
+                    :managed-dependencies])
       (assoc :local-repo-classpath true)
       (with-meta (meta project))))
 


### PR DESCRIPTION
# Current behaviour

As of [version 2.7.0](https://github.com/technomancy/leiningen/blob/master/NEWS.md#270--2016-08-24), Leiningen supports Maven's [managed dependencies](https://github.com/technomancy/leiningen/blob/master/doc/MANAGED_DEPS.md). When managed dependencies are used, version numbers in the `:dependencies` vector can be `nil` or left off entirely. If a dependency without a version is found, a separate ```:managed-dependencies``` key has to provide a version instead.

Here's what a very simple project using this would look like:

```clojure
(defproject foo "0.0.1-SNAPSHOT"
  :dependencies [[org.clojure/clojure]]
  :managed-dependencies [[org.clojure/clojure "1.8.0"]])
```

## Crashing with ```doo```

Because ```make-subproject``` uses ```select-keys``` and doesn't keep the ```:managed-dependencies``` key, these dependencies can't resolve and you get a crash like this:

```bash
$ lein doo phantom test once
java.lang.IllegalArgumentException: Provided artifact is missing a version: [cljs-ajax/cljs-ajax nil]
... imagine another 100 lines of stacktrace ...
```

# Fixing it, or choosing which fix to apply

The easy fix is to select the ```:managed-dependencies``` key as well.

That's what [```lein-figwheel does now```](https://github.com/bhauman/lein-figwheel/pull/506/files).

```lein-cljsbuild``` [also hit this bug](https://github.com/emezeske/lein-cljsbuild/issues/465), but the fix there was quite different. [Compare its implementation of ```make-subproject```](https://github.com/emezeske/lein-cljsbuild/blob/0d085f9c868bbc6b90f786fd23569bf89c124dea/plugin/src/leiningen/cljsbuild/subproject.clj#L84-L101).

Looking at the different versions and their git blame, it seems like ```make-subproject``` was first part of ```lein-cljsbuild```, then copied over to ```lein-figwheel```. So I'm tempted to consider ```lein-cljsbuild``` as the primary "upstream" for this function. And that version only changes ```:prep-tasks```.

## A possible different fix

If we're willing to make a more drastic change, I think we could simplify```make-subproject```. I don't think ```doo``` needs to change ```:prep-tasks``` like ```cljsbuild```. So:

```clojure
(defn make-subproject [project]
  (with-meta
    (assoc project :local-repo-classpath true)
    (meta project)))
```

Possibly with a docstring that explains it's a simplified version of what ```lein-cljsbuild``` has.

And to be honest, I don't even know if ```:local-repo-classpath``` is needed - there's [no mention of it in Leiningen now](https://github.com/technomancy/leiningen/search?q=local-repo-classpath&type=Code&utf8=%E2%9C%93), and the only [commits for it](https://github.com/technomancy/leiningen/search?q=local-repo-classpath&type=Commits&utf8=%E2%9C%93) are from 2011. It's possible it's needed to support very old Leiningen versions...?

# Testing

I ran ```lein test``` in the ```plugin``` folder and everything passed.

Both the currently committed fix and the simplified version avoid the crash on our project.