### PR TITLE
Only warn about init function being unset when it actually isn't set

### DIFF
--- a/library/src/doo/runner.cljs
+++ b/library/src/doo/runner.cljs
@@ -52,7 +52,7 @@
 ;; Karma starts the runner with arguments
 (defn ^:export run! [a]
   (if-not (fn? *main-cli-fn*)
-    (do (println "WARNING: doo's init function was not set")
+    (do (println "WARNING: doo's init function was not set or is not a function")
         (exit! false))
     (try
       (*main-cli-fn* a)

--- a/library/src/doo/runner.cljs
+++ b/library/src/doo/runner.cljs
@@ -51,7 +51,7 @@
 
 ;; Karma starts the runner with arguments
 (defn ^:export run! [a]
-  (if-not *main-cli-fn*
+  (if-not (fn? *main-cli-fn*)
     (do (println "WARNING: doo's init function was not set")
         (exit! false))
     (try

--- a/library/src/doo/runner.cljs
+++ b/library/src/doo/runner.cljs
@@ -59,11 +59,10 @@
       (catch :default e
         (println "\nERROR: Exception outside tests:")
         (println e)
-        (println "\nERROR: Stacktrace:")
-        (println
-         (if (.hasOwnProperty e "stack")
-           (.-stack e)
-           "No stacktrace available."))
+        (if (.hasOwnProperty e "stack")
+          (do (println "\nERROR: Stacktrace:")
+              (println (.-stack e)))
+          (println "\nNo stacktrace available."))
         (exit! false)))))
 
 (defn set-entry-point!

--- a/library/src/doo/runner.cljs
+++ b/library/src/doo/runner.cljs
@@ -51,12 +51,14 @@
 
 ;; Karma starts the runner with arguments
 (defn ^:export run! [a]
-  (try
-    (*main-cli-fn* a)
-    (catch :default e
-      (println "WARNING: doo's init function was not set")
-      (println e)
-      (exit! false))))
+  (if-not *main-cli-fn*
+    (do (println "WARNING: doo's init function was not set")
+        (exit! false))
+    (try
+      (*main-cli-fn* a)
+      (catch :default e
+        (println e)
+        (exit! false)))))
 
 (defn set-entry-point!
   "Sets the function to be run when starting the script"

--- a/library/src/doo/runner.cljs
+++ b/library/src/doo/runner.cljs
@@ -57,12 +57,15 @@
     (try
       (*main-cli-fn* a)
       (catch :default e
-        (println "\nERROR: Exception outside tests:")
-        (println e)
+        (println)
+        (println "ERROR: Exception outside tests:")
+        (println "ERROR:" e)
         (if (.hasOwnProperty e "stack")
-          (do (println "\nERROR: Stacktrace:")
-              (println (.-stack e)))
-          (println "\nNo stacktrace available."))
+          (do (println)
+              (println "ERROR: Stacktrace:")
+              (println "ERROR:" (.-stack e)))
+          (do (println)
+              (println "ERROR: No stacktrace available.")))
         (exit! false)))))
 
 (defn set-entry-point!

--- a/library/src/doo/runner.cljs
+++ b/library/src/doo/runner.cljs
@@ -57,7 +57,13 @@
     (try
       (*main-cli-fn* a)
       (catch :default e
+        (println "\nERROR: Exception outside tests:")
         (println e)
+        (println "\nERROR: Stacktrace:")
+        (println
+         (if (.hasOwnProperty e "stack")
+           (.-stack e)
+           "No stacktrace available."))
         (exit! false)))))
 
 (defn set-entry-point!


### PR DESCRIPTION
Discussion started in #122.

I think this is what the original code was trying to do: if `*main-cli-fn*` was `nil`, then you'd get an error trying to use `nil` as a function, catch that error, and report it. But there are many other reasons an exception might be thrown. A spurious warning will only distract people when they're trying to identify the real issue.

Are there other kinds of invalid values for `*main-cli-fn*`? If so, those should be checked as well as for `nil`.