### PR TITLE
Avoid unnecessary warnings about matchers

### DIFF
--- a/library/src/doo/karma.clj
+++ b/library/src/doo/karma.clj
@@ -77,9 +77,7 @@
                (when (= :none (:optimizations compiler-opts))
                  (mapv ->out-dir ["/goog/base.js" "/cljs_deps.js"]))
                [(:output-to compiler-opts)
-                {"pattern" (->out-dir "/**") "included" false}
-                {"pattern" (->out-dir "/**/*.js") "included" false}
-                {"pattern" (->out-dir "/*.js") "included" false}])
+                {"pattern" (->out-dir "/**") "included" false}])
      "autoWatch" false
      "client" {"args" ["doo.runner.run_BANG_"]}
      "singleRun" true}))


### PR DESCRIPTION
Having overlapping file patterns causes warnings like this:

```
WARN [watcher]: All files matched by "/Users/miikka/code/doo/example/out/**/*.js" were excluded or matched by prior matchers.
WARN [watcher]: All files matched by "/Users/miikka/code/doo/example/out/*.js" were excluded or matched by prior matchers.
```

The warnings are harmless, but it's not immediately obvious. This patch removes the unnecessary patterns to get rid of the warnings.