### PR TITLE
Add support for headless Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ in `project.clj`:
   `opera`, `slimer`, `phantom`, `node`, `rhino`, or `nashorn`. In the future it
   is planned to support `v8`, `jscore`, and others.
     * Note that `chrome-headless` requires `karma-chrome-launcher` >= 2.0.0 and Chrome >= 59
+    * Note that `firefox-headless` requires `karma-firefox-launcher` >= 1.1.0 and Firefox >= 56
 * `watch-mode` (optional): either `auto` (default) or `once` which
   exits with 0 if the tests were successful and 1 if they failed.
 * `build-id` is one of your `cljsbuild` profiles. For example `test` from:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ in `project.clj`:
 
     lein doo {js-env} {build-id} {watch-mode}
 
-* `js-env` can be any `chrome`, `chrome-headless`, `firefox`, `ie`, `safari`,
-  `opera`, `slimer`, `phantom`, `node`, `rhino`, or `nashorn`. In the future it
-  is planned to support `v8`, `jscore`, and others.
+* `js-env` can be any `chrome`, `chrome-headless`, `firefox`,`firefox-headless`,
+  `ie`, `safari`,`opera`, `slimer`, `phantom`, `node`, `rhino`, or `nashorn`.
+  In the future it is planned to support `v8`, `jscore`, and others.
     * Note that `chrome-headless` requires `karma-chrome-launcher` >= 2.0.0 and Chrome >= 59
     * Note that `firefox-headless` requires `karma-firefox-launcher` >= 1.1.0 and Firefox >= 56
 * `watch-mode` (optional): either `auto` (default) or `once` which
@@ -108,7 +108,8 @@ You can run `doo.core/run-script` with the following arguments:
 where:
 
 * `js-env` - any of `:phantom`, `:slimer`, :`node`, `:rhino`, `:nashorn`,
-  `:chrome`, `:chrome-headless`, `:firefox`, `:ie`, `:safari`, or `:opera`
+  `:chrome`, `:chrome-headless`, `:firefox`, `:firefox-headless`,`:ie`,
+  `:safari`, or `:opera`
 * `compiler-opts` - the options passed to the ClojureScript when it
   compiled the script that doo should run
 * `opts` - a map that can contain:

--- a/circle.yml
+++ b/circle.yml
@@ -42,6 +42,10 @@ test:
     - cd example && lein doo chrome-headless test once
     - cd example && lein doo chrome-headless advanced once
     - cd example && lein doo chrome-headless none-test once
+    # Firefox Headless
+    - cd example && lein doo firefox-headless test once
+    - cd example && lein doo firefox-headless advanced once
+    - cd example && lein doo firefox-headless none-test once
     # Rhino
     # rhino doesn't support :optimizations :none
     - cd example && lein doo rhino test once
@@ -85,6 +89,10 @@ test:
     - cd example && lein doo chrome-headless test-fail once && exit 1 || exit 0
     - cd example && lein doo chrome-headless advanced-fail once && exit 1 || exit 0
     - cd example && lein doo chrome-headless none-test-fail once && exit 1 || exit 0
+    # Firefox Headless
+    - cd example && lein doo firefox-headless test-fail once && exit 1 || exit 0
+    - cd example && lein doo firefox-headless advanced-fail once && exit 1 || exit 0
+    - cd example && lein doo firefox-headless none-test-fail once && exit 1 || exit 0
     # Rhino
     - cd example && lein doo rhino test-fail once && exit 1 || exit 0
     - cd example && lein doo rhino advanced-fail once && exit 1 || exit 0

--- a/library/src/doo/karma.clj
+++ b/library/src/doo/karma.clj
@@ -14,26 +14,28 @@
   (str "karma-" name "-launcher"))
 
 (def karma-envs
-  {:chrome          {:plugin (karma-plugin-name "chrome")
-                     :name   "Chrome"}
-   :chrome-canary   {:plugin (karma-plugin-name "chrome")
-                     :name   "ChromeCanary"}
-   :chrome-headless {:plugin (karma-plugin-name "chrome")
-                     :name   "ChromeHeadless"}
-   :firefox         {:plugin (karma-plugin-name "firefox")
-                     :name   "Firefox"}
-   :safari          {:plugin (karma-plugin-name "safari")
-                     :name   "Safari"}
-   :opera           {:plugin (karma-plugin-name "opera")
-                     :name   "Opera"}
-   :ie              {:plugin (karma-plugin-name "ie")
-                     :name   "IE"}
-   :karma-phantom   {:plugin (karma-plugin-name "phantomjs")
-                     :name   "PhantomJS"}
-   :karma-slimer    {:plugin (karma-plugin-name "slimerjs")
-                     :name   "SlimerJS"}
-   :electron        {:plugin (karma-plugin-name "electron")
-                     :name   "Electron"}})
+  {:chrome           {:plugin (karma-plugin-name "chrome")
+                      :name   "Chrome"}
+   :chrome-canary    {:plugin (karma-plugin-name "chrome")
+                      :name   "ChromeCanary"}
+   :chrome-headless  {:plugin (karma-plugin-name "chrome")
+                      :name   "ChromeHeadless"}
+   :firefox          {:plugin (karma-plugin-name "firefox")
+                      :name   "Firefox"}
+   :firefox-headless {:plugin (karma-plugin-name "firefox")
+                      :name   "FirefoxHeadless"}
+   :safari           {:plugin (karma-plugin-name "safari")
+                      :name   "Safari"}
+   :opera            {:plugin (karma-plugin-name "opera")
+                      :name   "Opera"}
+   :ie               {:plugin (karma-plugin-name "ie")
+                      :name   "IE"}
+   :karma-phantom    {:plugin (karma-plugin-name "phantomjs")
+                      :name   "PhantomJS"}
+   :karma-slimer     {:plugin (karma-plugin-name "slimerjs")
+                      :name   "SlimerJS"}
+   :electron         {:plugin (karma-plugin-name "electron")
+                      :name   "Electron"}})
 
 (def envs (set (keys karma-envs)))
 

--- a/library/test/clj/test/doo/core.clj
+++ b/library/test/clj/test/doo/core.clj
@@ -48,7 +48,7 @@
     (are [js-env] (doo/valid-js-env? js-env)
       :rhino :nashorn :slimer :phantom :node
       :chrome :safari :firefox :opera :ie :electron
-      :karma-phantom :karma-slimer :chrome-headless))
+      :karma-phantom :karma-slimer :chrome-headless :firefox-headless))
   (testing "We can resolve aliases"
     (are [alias js-envs] (= (doo/resolve-alias alias {}) js-envs)
          :phantom [:phantom]


### PR DESCRIPTION
The new version of https://github.com/karma-runner/karma-firefox-launcher (1.1.0) added support for launching firefox in headless mode. This pull-requests adds `firefox-headless` karma-env to start FirefoxHeadless plugin with `lein doo`.

You need Firefox >= 56 and karma-firefox-launcher >= 1.1.0 for testing.