### PR TITLE
Quote compiler options to allow raw symbols

### DIFF
--- a/plugin/src/leiningen/doo.clj
+++ b/plugin/src/leiningen/doo.clj
@@ -199,7 +199,7 @@ in project.clj.\n")
        ;; add-implicit-options should be only called once. cljs.build.api does it
        ;; internally but doo.core functions expect us to do it. That's why we have
        ;; compiler# and full-compiler#.
-       `(let [compiler# ~compiler
+       `(let [compiler# '~compiler
               full-compiler# (cljs.build.api/add-implicit-options compiler#)]
           (doseq [js-env# ~js-envs]
             (doo.core/assert-compiler-opts js-env# full-compiler#))


### PR DESCRIPTION
Related to #133 

Using [ClojureScript `:global-exports`](https://clojurescript.org/news/2017-07-30-global-exports) breaks `doo`.

Example:

```
(defproject some-project "0.1.0-SNAPSHOT"
  ...
  :plugins [[lein-doo "0.1.8"]]
  :cljs-builds
  [{:id "dev"
    ...
    :foreign-libs [:file "src/js/react.js"
                    :provides ["react"]
                    :global-exports {react React}]}])
```

Throws something like
```
Exception in thread "main" java.lang.RuntimeException: Unable to resolve symbol: react in this context, compiling:(/tmp/form-init3178254444106062114.clj:1:227)
	at clojure.lang.Compiler.analyze(Compiler.java:6792)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$MapExpr.parse(Compiler.java:3096)
	at clojure.lang.Compiler.analyze(Compiler.java:6781)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$MapExpr.parse(Compiler.java:3097)
	at clojure.lang.Compiler.analyze(Compiler.java:6781)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$VectorExpr.parse(Compiler.java:3253)
	at clojure.lang.Compiler.analyze(Compiler.java:6775)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$MapExpr.parse(Compiler.java:3097)
	at clojure.lang.Compiler.analyze(Compiler.java:6781)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$InvokeExpr.parse(Compiler.java:3881)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7005)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.access$300(Compiler.java:38)
	at clojure.lang.Compiler$LetExpr$Parser.parse(Compiler.java:6368)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:6991)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
	at clojure.lang.Compiler$TryExpr$Parser.parse(Compiler.java:2307)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7003)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.analyze(Compiler.java:6729)
	at clojure.lang.Compiler$BodyExpr$Parser.parse(Compiler.java:6100)
	at clojure.lang.Compiler$FnMethod.parse(Compiler.java:5460)
	at clojure.lang.Compiler$FnExpr.parse(Compiler.java:4022)
	at clojure.lang.Compiler.analyzeSeq(Compiler.java:7001)
	at clojure.lang.Compiler.analyze(Compiler.java:6773)
	at clojure.lang.Compiler.eval(Compiler.java:7059)
	at clojure.lang.Compiler.eval(Compiler.java:7052)
	at clojure.lang.Compiler.load(Compiler.java:7514)
	at clojure.lang.Compiler.loadFile(Compiler.java:7452)
	at clojure.main$load_script.invokeStatic(main.clj:278)
	at clojure.main$init_opt.invokeStatic(main.clj:280)
	at clojure.main$init_opt.invoke(main.clj:280)
	at clojure.main$initialize.invokeStatic(main.clj:311)
	at clojure.main$null_opt.invokeStatic(main.clj:345)
	at clojure.main$null_opt.invoke(main.clj:342)
	at clojure.main$main.invokeStatic(main.clj:424)
	at clojure.main$main.doInvoke(main.clj:387)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:702)
	at clojure.main.main(main.java:37)
Caused by: java.lang.RuntimeException: Unable to resolve symbol: react in this context
	at clojure.lang.Util.runtimeException(Util.java:221)
	at clojure.lang.Compiler.resolveIn(Compiler.java:7299)
	at clojure.lang.Compiler.resolve(Compiler.java:7243)
	at clojure.lang.Compiler.analyzeSymbol(Compiler.java:7204)
	at clojure.lang.Compiler.analyze(Compiler.java:6752)
	... 52 more
```

This is due to: https://github.com/bhauman/lein-figwheel/issues/544#issuecomment-292802057
`lein-doo` should quote the compiler configuration to allow raw symbols.

I ran tests on this commit and it went OK.  I also tested it in my local project (the one using `:global-exports`) and it worked.