### PR TITLE
Use humane-test-output for better reporting

### DIFF
--- a/library/project.clj
+++ b/library/project.clj
@@ -18,7 +18,7 @@
 
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/data.json "0.2.6"]
-                 [karma-reporter "2.1.2"]
+                 [org.clojars.nenadalm/karma-reporter "4.0.0"]
                  [meta-merge "1.0.0"]]
 
   :jvm-opts ["-Xmx1g"]


### PR DESCRIPTION
Hi. [humane-test-output](https://github.com/pjstadig/humane-test-output) has better reporting than [karma-reporter](https://github.com/honzabrecka/karma-reporter).

It was decided that `humane-test-output` won't be integrated into `karma-reporter` a while ago (https://github.com/honzabrecka/karma-reporter/pull/9#issuecomment-264980263). Now I am using clojurescript a bit more than before, so I thought it would be nice if my tests had better reports.

```clojure
(defrecord Person [fname lname])

(deftest rec-example
  (is (= (Person. "fir" "las")
         (Person. "fir" "last"))))
```

Before:
```
LOG: 'Testing app.db-test'
LOG: ''
LOG: 'ERROR: Exception outside tests:'
LOG: 'ERROR: #object[Error Error: Assert failed: (symbol? tag)]'
LOG: ''
LOG: 'ERROR: No stacktrace available.'
LOG: 'WARNING: doo's exit function was not properly set'
LOG: '#object[TypeError TypeError: doo.runner._STAR_exit_fn_STAR_ is null]'
```

After:
```
Firefox 59.0.0 (Fedora 0.0.0) app.db-test rec-example FAILED
	
	FAIL in (rec-example) (cljs/core.js:13393:8)
	
	, , expected: #app.db-test.Person{:fname "fir":lname "las"}
	  actual: #app.db-test.Person{:fname "fir":lname "last"}
	    diff: - {:lname "las"}
	          + {:lname "last"}


```