### PR TITLE
Support for self-hosted js-envs Lumo and Planck

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ in `project.clj`:
     lein doo {js-env} {build-id} {watch-mode}
 
 * `js-env` can be any `chrome`, `chrome-headless`, `firefox`,`firefox-headless`,
-  `ie`, `safari`,`opera`, `slimer`, `phantom`, `node`, `rhino`, or `nashorn`.
+  `ie`, `safari`,`opera`, `slimer`, `phantom`, `node`, `rhino`, `nashorn`, `lumo`, or `planck`.
   In the future it is planned to support `v8`, `jscore`, and others.
     * Note that `chrome-headless` requires `karma-chrome-launcher` >= 2.0.0 and Chrome >= 59
     * Note that `firefox-headless` requires `karma-firefox-launcher` >= 1.1.0 and Firefox >= 56
@@ -109,6 +109,7 @@ You can run `doo.core/run-script` with the following arguments:
 where:
 
 * `js-env` - any of `:phantom`, `:slimer`, :`node`, `:rhino`, `:nashorn`,
+  `:lumo`, `:planck`,
   `:chrome`, `:chrome-headless`, `:firefox`, `:firefox-headless`,`:ie`,
   `:safari`, or `:opera`
 * `compiler-opts` - the options passed to the ClojureScript when it
@@ -141,6 +142,10 @@ you need to install them so that these commands work on the command line:
     jjs -h
 
     rhino -help
+    
+    lumo -h
+    
+    planck -h
 
 If you want to use a different command to run a certain runner, see
 Paths.
@@ -329,6 +334,10 @@ After installing [Electron](http://electron.atom.io/releases/) install the launc
 and call
 
     lein doo electron test
+
+### Planck
+
+Planck `2.14.0` or later is required.
 
 ## Paths
 

--- a/plugin/src/leiningen/doo.clj
+++ b/plugin/src/leiningen/doo.clj
@@ -183,7 +183,8 @@ Usage:
 
   lein doo {js-env} {build-id} {watch-mode}
 
-  - js-env: slimer, phantom, node, chrome, firefox, or an alias like headless
+  - js-env: slimer, phantom, node, chrome, firefox, lumo, planck, or an
+            alias like headless
   - build-id: any of the ids under the :cljsbuild map in your project.clj
   - watch-mode: either auto (default) or once\n
 


### PR DESCRIPTION
Fixes #116 

This PR adds the ability to to `lein doo lumo` and `lein doo planck`.

Detailed notes:

Self-hosted ClojureScript doesn't require the ClojureScript compile build step (as `lumo` and `planck` operate directly on source, compiling in memory internally). So, in theory, while the build step is harmless, it could be omitted. But, it wasn't clear to me how this could be easily accomplished when the `auto` mode is in effect (because the ClojureScript compiler's watch capability is used). So, this PR does nothing with respect to the build step and preserves the existing logic.

Also, since `lumo` and `planck` don't need the results of the build, the `(:output-to compiler-opts)` final script runner command line argument is conditionally omitted for the self-hosted testing case. (If you look at the way `lumo` and `planck` are executed, they are directed to run the test by issuing a `require` on the `(:main compiler-opts)`.

I tried putting some of the self-hosted stuff into a separate namespace, with `defmethod`s for `:lumo` and `:planck`, which would be an appealing approach, but it is difficult to cleanly do this without wanting a circular dependency between `doo.core` and that new separate namespace. So this PR just keeps it simple and puts the self-hosted support directly in `doo.core`.

This PR works with the current `lumo` release. 

For `planck` recently-released version 2.14.0 is required, otherwise two issue arise which could be worked-around in `doo` but they are really `planck` defects: 

- Planck defect https://github.com/planck-repl/planck/issues/737 causes `doo.runner` to be reloaded after having set the `doo.runner/*exit-fn*`. A `doo` workaround would be to employ `defonce`, but this has been fixed in Planck 2.14.0.
- Planck defect https://github.com/planck-repl/planck/issues/735 causes `doo` complain that the `*exit-fn*` hasn't been properly set, owing to an artifact where Planck internally uses exceptions when `planck/exit` is called; this also has been fixed in Planck 2.14.0 thus making it compatible with the way `doo` catches `:default`