### PR TITLE
Log error stack trace (PhantomJS/SlimerJS)

### DIFF
--- a/library/resources/runners/headless.js
+++ b/library/resources/runners/headless.js
@@ -45,8 +45,11 @@ p.onConsoleMessage = function(msg) {
     console.log(msg);
 };
 
-p.onError = function(msg) {
+p.onError = function(msg, trace) {
     console.error(msg);
+    trace.forEach(function(item) {
+        console.log('  ' + item.file + ':' + item.line);
+    });
     exit(1);
 };
 


### PR DESCRIPTION
This PR modifies this output

```
;; ======================================================================
;; Testing with Phantom:

ReferenceError: Can't find variable: Map

  phantomjs://code/phantom8526881425544510795.js:81 in onError
Subprocess failed
```

to include stack trace

```
;; ======================================================================
;; Testing with Phantom:

ReferenceError: Can't find variable: Map

  phantomjs://code/phantom5344940102494846597.js:81 in onError
  file:///Users/iheikkinen/src/foobar/target/out/cljsjs/react-dom/development/react-dom.inc.js:6075
  file:///Users/iheikkinen/src/foobar/target/out/cljsjs/react-dom/development/react-dom.inc.js:15
Subprocess failed
```

so that troubleshooting is a bit easier.