### PR TITLE
Update the Clojure version required by the plugin

### DIFF
--- a/plugin/project.clj
+++ b/plugin/project.clj
@@ -12,7 +12,7 @@
 
   :eval-in-leiningen true
 
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.10.3" :scope "provided"]
                  [doo "0.1.12-SNAPSHOT"]]
 
   :test-paths ["test/clj" "test/cljs"]


### PR DESCRIPTION
Pulling such an old Clojure version could influence other plugins, making them fail.

This is reflected on https://github.com/clojure-emacs/cider/pull/3105 . We could work around the issue but would appreciate the improvement on Doo's side as well.

Cheers - V